### PR TITLE
Cleanly shut down EmulationStation if it is running

### DIFF
--- a/cs-osd/cs-osd.py
+++ b/cs-osd/cs-osd.py
@@ -418,14 +418,15 @@ def doShutdown():
     
     es_process_found = False
     for line in out.splitlines():
-        if not es_process_found:
-            path = line.split(None, 1)[1]
-            if path.startswith('/opt/retropie/supplementary/emulationstation/emulationstation'):
-                es_process_found = True
-                open('/tmp/es-shutdown', 'a').close()
-                pid = int(line.split(None, 1)[0])
-                os.kill(pid, signal.SIGTERM)
-                time.sleep(5)
+        path = line.split(None, 1)[1]
+        if path.startswith('/opt/retropie/supplementary/emulationstation/emulationstation'):
+            es_process_found = True
+            open('/tmp/es-shutdown', 'a').close()
+            pid = int(line.split(None, 1)[0])
+            os.kill(pid, signal.SIGTERM)
+    
+    if es_process_found:
+        time.sleep(5)
 
     os.system("sudo shutdown -h now")
 

--- a/cs-osd/cs-osd.py
+++ b/cs-osd/cs-osd.py
@@ -415,7 +415,6 @@ def checkTemperature():
 def doShutdown():
     proc = subprocess.Popen(['ps', '-C', 'emulationstation', '-o', 'pid,args'], stdout = subprocess.PIPE)
     out, err = proc.communicate()
-    es_process_found = False
     for line in out.splitlines():
         path = line.split(None, 1)[1]
         if path.startswith('/opt/retropie/supplementary/emulationstation/emulationstation'):
@@ -423,8 +422,9 @@ def doShutdown():
             open('/tmp/es-shutdown', 'a').close()
             pid = int(line.split(None, 1)[0])
             os.kill(pid, signal.SIGTERM)
-    if not es_process_found:
-        os.system("sudo shutdown -h now")
+            time.sleep(5)
+
+    os.system("sudo shutdown -h now")
 
     try:
         sys.stdout.close()

--- a/cs-osd/cs-osd.py
+++ b/cs-osd/cs-osd.py
@@ -415,14 +415,17 @@ def checkTemperature():
 def doShutdown():
     proc = subprocess.Popen(['ps', '-C', 'emulationstation', '-o', 'pid,args'], stdout = subprocess.PIPE)
     out, err = proc.communicate()
+    
+    es_process_found = False
     for line in out.splitlines():
-        path = line.split(None, 1)[1]
-        if path.startswith('/opt/retropie/supplementary/emulationstation/emulationstation'):
-            es_process_found = True
-            open('/tmp/es-shutdown', 'a').close()
-            pid = int(line.split(None, 1)[0])
-            os.kill(pid, signal.SIGTERM)
-            time.sleep(5)
+        if not es_process_found:
+            path = line.split(None, 1)[1]
+            if path.startswith('/opt/retropie/supplementary/emulationstation/emulationstation'):
+                es_process_found = True
+                open('/tmp/es-shutdown', 'a').close()
+                pid = int(line.split(None, 1)[0])
+                os.kill(pid, signal.SIGTERM)
+                time.sleep(5)
 
     os.system("sudo shutdown -h now")
 

--- a/cs-osd/cs-osd.py
+++ b/cs-osd/cs-osd.py
@@ -413,7 +413,19 @@ def checkTemperature():
 
 # Do a shutdown
 def doShutdown():
-    os.system("sudo shutdown -h now")
+    proc = subprocess.Popen(['ps', '-C', 'emulationstation', '-o', 'pid,args'], stdout = subprocess.PIPE)
+    out, err = proc.communicate()
+    es_process_found = False
+    for line in out.splitlines():
+        path = line.split(None, 1)[1]
+        if path.startswith('/opt/retropie/supplementary/emulationstation/emulationstation'):
+            es_process_found = True
+            open('/tmp/es-shutdown', 'a').close()
+            pid = int(line.split(None, 1)[0])
+            os.kill(pid, signal.SIGTERM)
+    if not es_process_found:
+        os.system("sudo shutdown -h now")
+
     try:
         sys.stdout.close()
     except:


### PR DESCRIPTION
This shuts down EmulationStation cleanly using ES' own shutdown mechanism. If ES is not running, it falls back to just running `sudo shutdown -h now` as it previously did.

Fixes #19 