### PR TITLE
Typo in Joystick 2 Enable

### DIFF
--- a/cs-configure.py
+++ b/cs-configure.py
@@ -384,7 +384,7 @@ Enter selection followed by ENTER: """)
     set_joystick_config(toggle_j1=True)
   elif key == '7':
     print(">>> Inverting JOY 2 enabled config..")
-    set_joystick_config(toggle_j1=True)
+    set_joystick_config(toggle_j2=True)
   elif key == '8':
     print(">>> Inverting ANALOG VOLUME enabled config..")
     toggle_avol()


### PR DESCRIPTION
I found a typo in the python code for Enabling/Disabling Joystick 2.  Instead of updating j2, it was updating j1.